### PR TITLE
Updated peri-tumoral for 2D MG images

### DIFF
--- a/preprocessingComponents/+createPeriTumoralRegion/private/createPeriTumoralRegion2D.m
+++ b/preprocessingComponents/+createPeriTumoralRegion/private/createPeriTumoralRegion2D.m
@@ -1,0 +1,32 @@
+function [ periTumoralVOI ] = createPeriTumoralRegion2D(segmentationVOI, operation, distance, xSpacing, ySpacing)
+% CREATEPERITUMORALREGION This function will create a 2D peri-tumoral region (ie. an expansion surrounding the tumor segmentation) 
+%           with a distance specified (in mm). Initial implemention for 2D mammogram images.
+% Created by:       Sarah Mattonen
+% Created on:       2019-04-15
+
+%% Create expanded ROI
+voxelDimensions = [xSpacing, ySpacing, 1];
+distanceTransformSegmentationVOI = zeros(size(segmentationVOI));
+
+% Perform the distance transform from the tumor segmentation on each 2D slice
+for slice = 1:size(segmentationVOI,3) % Go through each slice
+        thisSlice = segmentationVOI(:,:,slice);
+        if any(thisSlice(:)) % Check if this slice contains the segmentation
+            distanceTransformSegmentationSlice = bwdistsc1({thisSlice}, voxelDimensions, distance*2);
+            distanceTransformSegmentationVOI(:,:,slice) = cell2mat(distanceTransformSegmentationSlice);
+        else
+            distanceTransformSegmentationVOI(:,:,slice) = thisSlice;
+        end
+end
+
+% Determine whether to include or exclude segmentationVOI in final VOI
+if (strcmp(operation, 'include'))
+    periTumoralVOI = (distanceTransformSegmentationVOI <= distance);           
+elseif (strcmp(operation, 'exclude'))
+    periTumoralVOI = (distanceTransformSegmentationVOI <= distance) & (distanceTransformSegmentationVOI > 0);           
+else
+    periTumoralVOI = segmentationVOI;
+    logger('WARN', ['Could not complete preprocessing component createPeriTumoralRegion: Invalid operation specified.']);
+end
+  
+end 

--- a/preprocessingComponents/+createPeriTumoralRegion/private/createPeriTumoralRegion3D.m
+++ b/preprocessingComponents/+createPeriTumoralRegion/private/createPeriTumoralRegion3D.m
@@ -1,4 +1,4 @@
-function [ periTumoralVOI ] = createPeriTumoralRegion(segmentationVOI, operation, distance, xSpacing, ySpacing, zSpacing)
+function [ periTumoralVOI ] = createPeriTumoralRegion3D(segmentationVOI, operation, distance, xSpacing, ySpacing, zSpacing)
 % CREATEPERITUMORALREGION This function will create a 3D peri-tumoral region (ie. an expansion surrounding the tumor segmentation) 
 %           with a distance specified (in mm)
 % Created by:       Sarah Mattonen

--- a/preprocessingComponents/+createPeriTumoralRegion/run.m
+++ b/preprocessingComponents/+createPeriTumoralRegion/run.m
@@ -7,15 +7,21 @@ function [ out ] = run( inputs )
     operation = inputs.operation;
     distance = inputs.distance;
     
-    %% Calculate pixel voxel sizes
-    % Find pixel spacing in millimeters in plane and between planes
-    ySpacing = abs(infoVOI{1}.PixelSpacing(1));
-    xSpacing = abs(infoVOI{1}.PixelSpacing(2));
-    zSpacing = abs(infoVOI{2}.ImagePositionPatient(3) - infoVOI{1}.ImagePositionPatient(3));
+    %% Calculate voxel sizes and create new segmentation
+    % Find voxel spacing in millimeters the create new peri-tumoral segmentation
+    if infoVOI{1, 1}.Modality == 'MG'   % If mammogram, create a 2D peri-tumoral region
+        ySpacing = abs(infoVOI{1, 1}.ImagerPixelSpacing(1));
+        xSpacing = abs(infoVOI{1, 1}.ImagerPixelSpacing(2));
+        
+        newVOI = createPeriTumoralRegion2D(segmentationVOI, operation, distance, xSpacing, ySpacing);
+    else
+        ySpacing = abs(infoVOI{1}.PixelSpacing(1));
+        xSpacing = abs(infoVOI{1}.PixelSpacing(2));
+        zSpacing = abs(infoVOI{2}.ImagePositionPatient(3) - infoVOI{1}.ImagePositionPatient(3));
+        
+        newVOI = createPeriTumoralRegion3D(segmentationVOI, operation, distance, xSpacing, ySpacing, zSpacing);
+    end
     
-    %% Calculate New Segmentation
-    newVOI = createPeriTumoralRegion(segmentationVOI, operation, distance, xSpacing, ySpacing, zSpacing);
-      
     %% Return New Segmentation
     out = { ... 
         struct(...


### PR DESCRIPTION
Updated peri-tumoral pre-processing function to account for mammogram images, in which we only want to create the per-tumoral region in 2D.